### PR TITLE
Zameet/feature adding shortcut keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Pseudo Refresh is a Chrome extension designed to automatically refresh the curre
 ### Functionality
 
 - **Randomized Refresh Interval**: The extension uses a combination of minimum and maximum seconds, along with milliseconds, to calculate a random interval for refreshing the tab.
-- **Toggle Activation**: Easily enable or disable the auto-refresh feature using the toggle button in the popup interface.
+- **Toggle Activation**: Easily enable or disable the auto-refresh feature using the toggle button in the popup interface or use shorcut keys (CTRL+SHIFT+E)
 - **Persistent Settings**: All settings are stored locally in Chrome's storage, ensuring your preferences are retained across browser sessions.
 
 ## Setup

--- a/background.js
+++ b/background.js
@@ -1,6 +1,15 @@
 let refreshInterval;
 let isEnabled = false;
 
+chrome.commands.onCommand.addListener((command) => {
+  console.log(`Command: ${command}`);
+  if (command === "enable_or_disable") {
+    chrome.storage.local.get(['isEnabled'], (result) => {
+      chrome.storage.local.set({ isEnabled: !result.isEnabled });
+    });
+  }
+});
+
 function getRandomNumber(min, max) {
   if (min > max) {
     [min, max] = [max, min];
@@ -58,7 +67,7 @@ function startRefreshing() {
       chrome.tabs.reload(() => {
         startRefreshing();
       });
-    console.log(completeInterval)
+      console.log(completeInterval)
     }, completeInterval * 1000);
   });
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Pseudo Refresh",
-  "version": "1.0",
+  "version": "1.1",
   "action": {
     "default_popup": "popup.html",
     "default_icon": {
@@ -12,11 +12,20 @@
   },
   "permissions": [
     "storage",
+    "commands",
     "tabs"
   ],
   "background": {
     "service_worker": "background.js"
   },
+  "commands": {
+    "enable_or_disable": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+E"
+      },
+      "description": "Capture Ctrl+E"
+    }
+  },  
   "icons": {
     "16": "images/icon.png",
     "48": "images/icon.png",


### PR DESCRIPTION
Added handling for using shortcut keys to enable and disable Pseudo Refresher.

- Use of CTRL+SHIFT+E to toggle Enable/Disable
- Updated manifest.json along with adding extra permission for commands
- Added key capture logic in service worker **background.js**